### PR TITLE
SEND ROUTES: Send Out Route Updates

### DIFF
--- a/network.py
+++ b/network.py
@@ -1,3 +1,4 @@
+import json
 import queue
 import threading
 
@@ -192,9 +193,9 @@ class Router:
     ## send out route update
     # @param i Interface number on which to send out a routing update
     def send_routes(self, i):
-        # TODO: Send out a routing table update
+        pbody = self.name + " " + json.dumps(self.rt_tbl_D)
         #create a routing table update packet
-        p = NetworkPacket(0, 'control', 'DUMMY_ROUTING_TABLE')
+        p = NetworkPacket(0, 'control', pbody)
         try:
             print('%s: sending routing update "%s" from interface %d' % (self, p, i))
             self.intf_L[i].put(p.to_byte_S(), 'out', True)


### PR DESCRIPTION
Currently `Router.send_routes()` does not send route updates correctly. Modify that function to send out route updates as defined in the distance-vector protocol discussed in class and your textbook. You will need to come up with a message that encodes the state of your routing tables.