### PR TITLE
UPDATE ROUTES: update the routing tables using the Bellman-Ford equation

### DIFF
--- a/network.py
+++ b/network.py
@@ -212,9 +212,15 @@ class Router:
         # determine which router sent the update
         r = pbody[NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+1:NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+3]
         # extract the distance vector
-        rtable = json.loads(pbody[NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+3:])
+        rvec = json.loads(pbody[NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+3:])
 
-        # update according to Bellman-Ford
+        # for each destination listed in the current routing table,
+        # update the cost vector at r to the new value
+        for dst, cvec in self.self.rt_tbl_D.items():
+            cvec[r] = rvec[dst][r]
+
+        # update according to Bellman-Ford equation
+
 
         print('%s: Received routing update %s from interface %d' % (self, p, i))
 

--- a/network.py
+++ b/network.py
@@ -193,7 +193,7 @@ class Router:
     ## send out route update
     # @param i Interface number on which to send out a routing update
     def send_routes(self, i):
-        pbody = self.name + " " + json.dumps(self.rt_tbl_D)
+        pbody = self.name + json.dumps(self.rt_tbl_D)
         #create a routing table update packet
         p = NetworkPacket(0, 'control', pbody)
         try:
@@ -204,11 +204,18 @@ class Router:
             pass
 
 
-    ## forward the packet according to the routing table
+    # update the routing tables according to the received distance vector
+    # and possibly send out routing updates
     #  @param p Packet containing routing information
     def update_routes(self, p, i):
-        #TODO: add logic to update the routing tables and
-        # possibly send out routing updates
+        pbody = str(p)
+        # determine which router sent the update
+        r = pbody[NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+1:NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+3]
+        # extract the distance vector
+        rtable = json.loads(pbody[NetworkPacket.dst_S_length+NetworkPacket.prot_S_length+3:])
+
+        # update according to Bellman-Ford
+
         print('%s: Received routing update %s from interface %d' % (self, p, i))
 
 

--- a/network.py
+++ b/network.py
@@ -244,6 +244,9 @@ class Router:
                     ycvec[self.name] = bf
 
         # push update
+        if updated:
+            for i in range(len(self.intf_L)):
+                self.send_routes(i)
 
         print('%s: Received routing update %s from interface %d' % (self, p, i))
 


### PR DESCRIPTION
Currently `Router.update_routes()` does not update routes correctly. Modify that function to update the routing tables using the Bellman-Ford equation based on updates from Router.send_routes(). Be aware that receiving an update may mean that you will need to send an update as well!